### PR TITLE
Adding a Menu Controller for searching menu items and searching menu …

### DIFF
--- a/backend/Controllers/MenuController.cs
+++ b/backend/Controllers/MenuController.cs
@@ -10,7 +10,7 @@ using Microsoft.EntityFrameworkCore;
 namespace backend.Controllers
 {
         [ApiController]
-        [Route("api/[controller]")]
+        [Route("api/menu")]
         public class MenuController : ControllerBase
         {
             private readonly ApplicationDBContext _context;

--- a/backend/Controllers/MenuController.cs
+++ b/backend/Controllers/MenuController.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using backend.Models;
+using backend.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace backend.Controllers
+{
+        [ApiController]
+        [Route("api/[controller]")]
+        public class MenuController : ControllerBase
+        {
+            private readonly ApplicationDBContext _context;
+
+            public MenuController(ApplicationDBContext context)
+            {
+                _context = context;
+            }
+
+            // GET: api/menu/category/{categoryId}
+            [HttpGet("category/{categoryId}")]
+            public async Task<ActionResult<IEnumerable<MenuItem>>> GetMenuItemsByCategory(int categoryId)
+            {
+                var items = await _context.MenuItems
+                    .Where(mi => mi.CategoryId == categoryId && mi.IsAvailable)
+                    .ToListAsync();
+                return Ok(items);
+            }
+
+            // GET: api/menu/search?query=xxx
+            [HttpGet("search")]
+            public async Task<ActionResult<IEnumerable<MenuItem>>> SearchMenuItems([FromQuery] string query)
+            {
+                if (string.IsNullOrWhiteSpace(query))
+                    return BadRequest("Query parameter is required.");
+
+                var items = await _context.MenuItems
+                    .Where(mi => mi.IsAvailable &&
+                        (EF.Functions.Like(mi.Name, $"%{query}%") ||
+                         EF.Functions.Like(mi.Description, $"%{query}%")))
+                    .ToListAsync();
+                return Ok(items);
+            }
+        }
+}


### PR DESCRIPTION
Adding a Menu Controller for searching menu items listed in the database and searching for a menu by category.

I've implemented two endpoints:

Display food by category
GET /api/menu/category/{categoryId} (can be changed to categoryname if necessary)— Get menu items by category

Search for food
GET /api/menu/search?query=xxx — Search menu items by name or description

I decided to put all of them inside the MenuController.cs as they are connected. But I've made sure to separate them into two different public async, in this way, we can edit either of them without affecting the other one. 

This is not yet the final output. So, I would like confirmation tomorrow, Saturday.



